### PR TITLE
Revert "Bump turbo-rails from 7.1.0 to 7.1.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -643,7 +643,7 @@ GEM
     thor (1.0.1)
     tilt (2.0.10)
     tomlrb (2.0.1)
-    turbo-rails (7.1.1)
+    turbo-rails (7.1.0)
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Reverts evemonk/evemonk#2245